### PR TITLE
Do not attach null.iso when starting VMs

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -209,9 +209,9 @@ vm::run(){
 
         # set full iso path
         # use null.iso if not an install and uefi firmware
-        [ -n "${_iso}" ] && _iso_dev="-s 3:0,ahci-cd,${_iso}"
-        [ -z "${_iso}" -a -n "${_uefi}" -a "${_uefi}" != "csm" ] && \
-            _iso_dev="-s 3:0,ahci-cd,${vm_dir}/.config/null.iso"
+        #[ -n "${_iso}" ] && _iso_dev="-s 3:0,ahci-cd,${_iso}"
+        #[ -z "${_iso}" -a -n "${_uefi}" -a "${_uefi}" != "csm" ] && \
+        #    _iso_dev="-s 3:0,ahci-cd,${vm_dir}/.config/null.iso"
 
         # reasonably ugly hack to remove wait option after first run
         [ "${_run}" -eq "2" ] && vm::bhyve_device_fbuf_clear_wait


### PR DESCRIPTION
* This causes issues booting newer versions of FreeBSD 11-STABLE, and CURRENT snapshots.